### PR TITLE
Remove unnecessary `await`

### DIFF
--- a/_11ty/createScreenshots.js
+++ b/_11ty/createScreenshots.js
@@ -46,7 +46,7 @@ const start = async () => {
   const page = await browser.newPage();
 
   const urls = await parseSitemap();
-  for await (const url of urls) {
+  for (const url of urls) {
     const output =
         `./_site/${url.replace('https://blog.tomayac.com/', '')}screenshot`;
     await createScreenshots(page, url, output);


### PR DESCRIPTION
`await parseSitemap()` results in a plain array of strings, so there's no point in awaiting each individual element. (It's an iterator, not an async iterator.)